### PR TITLE
feat(alerts): per-place alerts tab with live feed and resolve action

### DIFF
--- a/src/app/layouts/DefaultLayout.vue
+++ b/src/app/layouts/DefaultLayout.vue
@@ -10,7 +10,10 @@ const ui = useUiStore();
 
 const mainClasses = computed(() => {
   if (!isDesktop.value) return "px-4 pt-4 pb-20";
-  return ["px-8 pt-8 transition-[margin] duration-200", ui.sidebarCollapsed ? "ml-16" : "ml-64"];
+  return [
+    "px-8 pt-8 pb-8 transition-[margin] duration-200",
+    ui.sidebarCollapsed ? "ml-16" : "ml-64",
+  ];
 });
 </script>
 

--- a/src/app/styles/variables.css
+++ b/src/app/styles/variables.css
@@ -16,6 +16,11 @@
   --color-text-secondary: #6b7280;
   --color-danger: #e85a4f;
   --color-danger-hover: #d14b41;
+  --color-danger-bg: rgba(232, 90, 79, 0.1);
+  --color-danger-text: #b91c1c;
+  --color-warning: #d97706;
+  --color-warning-bg: rgba(245, 158, 11, 0.12);
+  --color-warning-text: #b45309;
   --color-success: #22c55e;
   --color-status-online-bg: rgba(34, 197, 94, 0.08);
   --color-status-online-text: #16a34a;
@@ -72,6 +77,11 @@
   --color-text-primary: #e5e5e5;
   --color-text-secondary: #737373;
   --color-accent-light: rgba(110, 158, 249, 0.12);
+  --color-danger-bg: rgba(232, 90, 79, 0.15);
+  --color-danger-text: #fca5a5;
+  --color-warning: #fbbf24;
+  --color-warning-bg: rgba(245, 158, 11, 0.15);
+  --color-warning-text: #fde68a;
   --color-status-online-bg: rgba(34, 197, 94, 0.15);
   --color-status-online-text: #4ade80;
   --color-status-offline-bg: rgba(115, 115, 115, 0.15);

--- a/src/entities/alert/api/alert.api.ts
+++ b/src/entities/alert/api/alert.api.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
+import { computed, type Ref } from "vue";
+import type { Alert, AlertListFilters } from "../model/types";
+import { api } from "@/shared/api/client";
+import { queryKeys } from "@/shared/api/query-keys";
+import type { PaginatedResponse } from "@/shared/api/types";
+
+function buildParams(filters: AlertListFilters): Record<string, string> {
+  const params: Record<string, string> = { per_page: "100" };
+  if (filters.severity) params.severity = filters.severity;
+  if (filters.sensor_id) params.sensor_id = filters.sensor_id;
+  if (filters.status) params.status = filters.status;
+  if (filters.from) params.from = filters.from;
+  return params;
+}
+
+export function useAlerts(
+  placeId: Ref<string> | string,
+  filters: Ref<AlertListFilters> | AlertListFilters,
+) {
+  return useQuery({
+    queryKey: computed(() => {
+      const pId = typeof placeId === "string" ? placeId : placeId.value;
+      const f = "value" in filters ? filters.value : filters;
+      return queryKeys.alerts.list(pId, buildParams(f));
+    }),
+    queryFn: async () => {
+      const pId = typeof placeId === "string" ? placeId : placeId.value;
+      const f = "value" in filters ? filters.value : filters;
+      const { data } = await api.get<PaginatedResponse<Alert>>(`/api/places/${pId}/alerts`, {
+        params: buildParams(f),
+      });
+      return data.items;
+    },
+  });
+}
+
+export function useResolveAlert(placeId: Ref<string> | string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (alertId: string) => {
+      const pId = typeof placeId === "string" ? placeId : placeId.value;
+      const { data } = await api.post<Alert>(`/api/places/${pId}/alerts/${alertId}/resolve`);
+      return data;
+    },
+    onSuccess: () => {
+      const pId = typeof placeId === "string" ? placeId : placeId.value;
+      queryClient.invalidateQueries({ queryKey: ["alerts", pId] });
+    },
+  });
+}

--- a/src/entities/alert/model/types.ts
+++ b/src/entities/alert/model/types.ts
@@ -1,0 +1,65 @@
+export type AlertSeverity = "warning" | "critical";
+export type AlertStatus = "active" | "resolved";
+export type AlertThresholdType = "min" | "max";
+export type AlertEventType = "created" | "resolved";
+
+export interface Alert {
+  id: string;
+  place_id: string;
+  device_id: string;
+  sensor_id: string;
+  threshold_id: string;
+  key: string;
+  value: number;
+  threshold_value: number;
+  threshold_type: AlertThresholdType;
+  severity: AlertSeverity;
+  status: AlertStatus;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export interface AlertMqttPayload extends Omit<Alert, "status"> {
+  event_type: AlertEventType;
+}
+
+export interface AlertListFilters {
+  severity?: AlertSeverity;
+  sensor_id?: string;
+  status?: AlertStatus;
+  from?: string;
+}
+
+export const ALERT_SEVERITY_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "All severities" },
+  { value: "warning", label: "Warning" },
+  { value: "critical", label: "Critical" },
+];
+
+export const ALERT_STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "All statuses" },
+  { value: "active", label: "Active" },
+  { value: "resolved", label: "Resolved" },
+];
+
+export const ALERT_TIME_RANGE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "All time" },
+  { value: "1h", label: "Last hour" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+];
+
+export function timeRangeToIso(range: string): string | undefined {
+  if (!range) return undefined;
+  const now = Date.now();
+  const offsets: Record<string, number> = {
+    "1h": 60 * 60 * 1000,
+    "24h": 24 * 60 * 60 * 1000,
+    "7d": 7 * 24 * 60 * 60 * 1000,
+    "30d": 30 * 24 * 60 * 60 * 1000,
+  };
+  const ms = offsets[range];
+  if (!ms) return undefined;
+  return new Date(now - ms).toISOString();
+}

--- a/src/features/manage-sensors/ManageThresholdsModal.vue
+++ b/src/features/manage-sensors/ManageThresholdsModal.vue
@@ -100,7 +100,7 @@ function handleRemove(thresholdId: string) {
           class="flex items-center justify-between py-2"
         >
           <div class="flex items-center gap-2">
-            <UiBadge :variant="t.severity === 'critical' ? 'danger' : 'accent'">
+            <UiBadge :variant="t.severity === 'critical' ? 'danger' : 'warning'">
               {{ t.severity }}
             </UiBadge>
             <span class="text-sm text-[var(--color-text-primary)]">

--- a/src/pages/place-alerts/PlaceAlertsPage.vue
+++ b/src/pages/place-alerts/PlaceAlertsPage.vue
@@ -1,15 +1,200 @@
 <script setup lang="ts">
-import { Bell } from "lucide-vue-next";
+import { computed, inject, reactive } from "vue";
+import { AlertTriangle, Bell, Check } from "lucide-vue-next";
+import { placeDetailKey } from "@/pages/place-detail/context";
+import { useAlerts, useResolveAlert } from "@/entities/alert/api/alert.api";
+import { useDevicesWithDetails } from "@/entities/device/api/device.api";
+import {
+  ALERT_SEVERITY_OPTIONS,
+  ALERT_STATUS_OPTIONS,
+  ALERT_TIME_RANGE_OPTIONS,
+  timeRangeToIso,
+  type Alert,
+  type AlertListFilters,
+  type AlertSeverity,
+  type AlertStatus,
+} from "@/entities/alert/model/types";
+import UiSelect from "@/shared/ui/UiSelect.vue";
+import UiSpinner from "@/shared/ui/UiSpinner.vue";
 import UiEmptyState from "@/shared/ui/UiEmptyState.vue";
+import UiBadge from "@/shared/ui/UiBadge.vue";
+import UiButton from "@/shared/ui/UiButton.vue";
+import { useToast } from "@/shared/composables/useToast";
+import { getErrorMessage } from "@/shared/api/types";
+
+const ctx = inject(placeDetailKey);
+if (!ctx) throw new Error("PlaceAlertsPage must be nested inside PlaceDetailPage");
+const { placeId, canManage, alerts: liveAlerts } = ctx;
+
+const toast = useToast();
+
+const uiFilters = reactive<{
+  severity: string;
+  sensor_id: string;
+  status: string;
+  range: string;
+}>({
+  severity: "",
+  sensor_id: "",
+  status: "",
+  range: "24h",
+});
+
+const queryFilters = computed<AlertListFilters>(() => ({
+  severity: (uiFilters.severity || undefined) as AlertSeverity | undefined,
+  sensor_id: uiFilters.sensor_id || undefined,
+  status: (uiFilters.status || undefined) as AlertStatus | undefined,
+  from: timeRangeToIso(uiFilters.range),
+}));
+
+const { data: historical, isLoading } = useAlerts(placeId, queryFilters);
+const { data: devices } = useDevicesWithDetails(placeId);
+const { mutate: resolveMutate, isPending: isResolving } = useResolveAlert(placeId);
+
+const sensorOptions = computed(() => {
+  const opts: { value: string; label: string }[] = [{ value: "", label: "All sensors" }];
+  const seen = new Set<string>();
+  for (const device of devices.value ?? []) {
+    for (const sensor of device.sensors) {
+      if (seen.has(sensor.sensor_id)) continue;
+      seen.add(sensor.sensor_id);
+      opts.push({
+        value: sensor.sensor_id,
+        label: `${device.name} · ${sensor.name || sensor.key}`,
+      });
+    }
+  }
+  return opts;
+});
+
+const sensorLabelById = computed(() => {
+  const map = new Map<string, string>();
+  for (const device of devices.value ?? []) {
+    for (const sensor of device.sensors) {
+      map.set(sensor.sensor_id, `${device.name} · ${sensor.name || sensor.key}`);
+    }
+  }
+  return map;
+});
+
+function matchesFilters(a: Alert): boolean {
+  if (uiFilters.severity && a.severity !== uiFilters.severity) return false;
+  if (uiFilters.sensor_id && a.sensor_id !== uiFilters.sensor_id) return false;
+  if (uiFilters.status && a.status !== uiFilters.status) return false;
+  const fromIso = timeRangeToIso(uiFilters.range);
+  if (fromIso && new Date(a.created_at) < new Date(fromIso)) return false;
+  return true;
+}
+
+const mergedAlerts = computed<Alert[]>(() => {
+  const byId = new Map<string, Alert>();
+  for (const a of historical.value ?? []) {
+    byId.set(a.id, a);
+  }
+  for (const a of liveAlerts.value) {
+    if (!matchesFilters(a)) {
+      if (byId.has(a.id)) byId.set(a.id, a);
+      continue;
+    }
+    byId.set(a.id, a);
+  }
+  return Array.from(byId.values())
+    .filter(matchesFilters)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+});
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function describeBreach(a: Alert): string {
+  const comparator = a.threshold_type === "max" ? "exceeded max" : "fell below min";
+  return `${a.value} ${comparator} ${a.threshold_value}`;
+}
+
+function onResolve(alertId: string) {
+  resolveMutate(alertId, {
+    onSuccess: () => toast.success("Alert resolved"),
+    onError: (e) => toast.error(getErrorMessage(e)),
+  });
+}
 </script>
 
 <template>
-  <UiEmptyState
-    title="Coming soon"
-    description="Threshold breaches and device alerts for this place will appear here."
-  >
-    <template #icon>
-      <Bell class="h-12 w-12 text-[var(--color-text-secondary)] opacity-40 mb-4" />
-    </template>
-  </UiEmptyState>
+  <div class="flex flex-col gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <UiSelect v-model="uiFilters.severity" label="Severity" :options="ALERT_SEVERITY_OPTIONS" />
+      <UiSelect v-model="uiFilters.sensor_id" label="Sensor" :options="sensorOptions" />
+      <UiSelect v-model="uiFilters.status" label="Status" :options="ALERT_STATUS_OPTIONS" />
+      <UiSelect v-model="uiFilters.range" label="Period" :options="ALERT_TIME_RANGE_OPTIONS" />
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-16">
+      <UiSpinner size="lg" />
+    </div>
+
+    <UiEmptyState
+      v-else-if="!mergedAlerts.length"
+      title="No alerts"
+      description="No alerts match the current filters."
+    >
+      <template #icon>
+        <Bell class="h-12 w-12 text-[var(--color-text-secondary)] opacity-40 mb-4" />
+      </template>
+    </UiEmptyState>
+
+    <ul v-else class="flex flex-col gap-2">
+      <li
+        v-for="alert in mergedAlerts"
+        :key="alert.id"
+        class="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-4"
+      >
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div class="flex items-start gap-3 min-w-0">
+            <AlertTriangle
+              class="h-5 w-5 shrink-0 mt-0.5"
+              :class="
+                alert.severity === 'critical'
+                  ? 'text-[var(--color-danger)]'
+                  : 'text-[var(--color-accent)]'
+              "
+            />
+            <div class="min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <UiBadge :variant="alert.severity === 'critical' ? 'danger' : 'accent'">
+                  {{ alert.severity }}
+                </UiBadge>
+                <UiBadge :variant="alert.status === 'resolved' ? 'success' : 'default'">
+                  {{ alert.status }}
+                </UiBadge>
+                <span class="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                  {{ sensorLabelById.get(alert.sensor_id) ?? alert.key }}
+                </span>
+              </div>
+              <div class="mt-1 text-sm text-[var(--color-text-secondary)]">
+                {{ describeBreach(alert) }}
+              </div>
+              <div class="mt-1 text-xs text-[var(--color-text-secondary)]">
+                Triggered {{ formatTime(alert.created_at) }}
+                <template v-if="alert.resolved_at">
+                  · Resolved {{ formatTime(alert.resolved_at) }}
+                </template>
+              </div>
+            </div>
+          </div>
+          <div v-if="canManage && alert.status === 'active'" class="shrink-0">
+            <UiButton
+              variant="secondary"
+              size="sm"
+              :loading="isResolving"
+              @click="onResolve(alert.id)"
+            >
+              <Check class="h-4 w-4 mr-1" />
+              Resolve
+            </UiButton>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
 </template>

--- a/src/pages/place-alerts/PlaceAlertsPage.vue
+++ b/src/pages/place-alerts/PlaceAlertsPage.vue
@@ -156,15 +156,15 @@ function onResolve(alertId: string) {
               :class="
                 alert.severity === 'critical'
                   ? 'text-[var(--color-danger)]'
-                  : 'text-[var(--color-accent)]'
+                  : 'text-[var(--color-warning)]'
               "
             />
             <div class="min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
-                <UiBadge :variant="alert.severity === 'critical' ? 'danger' : 'accent'">
+                <UiBadge :variant="alert.severity === 'critical' ? 'danger' : 'warning'">
                   {{ alert.severity }}
                 </UiBadge>
-                <UiBadge :variant="alert.status === 'resolved' ? 'success' : 'default'">
+                <UiBadge :variant="alert.status === 'resolved' ? 'success' : 'accent'">
                   {{ alert.status }}
                 </UiBadge>
                 <span class="text-sm font-medium text-[var(--color-text-primary)] truncate">

--- a/src/pages/place-detail/PlaceDetailPage.vue
+++ b/src/pages/place-detail/PlaceDetailPage.vue
@@ -20,7 +20,7 @@ const canManage = computed(
   () => place.value?.user_role === "owner" || place.value?.user_role === "admin",
 );
 
-const { latestValues } = useMqtt(placeId);
+const { latestValues, alerts } = useMqtt(placeId);
 
 watch(
   devices,
@@ -50,7 +50,7 @@ watch(
   { immediate: true },
 );
 
-provide(placeDetailKey, { placeId, canManage, latestValues });
+provide(placeDetailKey, { placeId, canManage, latestValues, alerts });
 </script>
 
 <template>

--- a/src/pages/place-detail/context.ts
+++ b/src/pages/place-detail/context.ts
@@ -1,9 +1,11 @@
 import type { ComputedRef, InjectionKey, Ref } from "vue";
+import type { Alert } from "@/entities/alert/model/types";
 
 export interface PlaceDetailContext {
   placeId: ComputedRef<string>;
   canManage: ComputedRef<boolean>;
   latestValues: Ref<Map<string, Map<string, { value: number; timestamp: string }>>>;
+  alerts: Ref<Alert[]>;
 }
 
 export const placeDetailKey: InjectionKey<PlaceDetailContext> = Symbol("placeDetail");

--- a/src/shared/api/query-keys.ts
+++ b/src/shared/api/query-keys.ts
@@ -23,6 +23,10 @@ export const queryKeys = {
     list: (placeId: string, deviceId: string, sensorId: string) =>
       ["thresholds", placeId, deviceId, sensorId] as const,
   },
+  alerts: {
+    list: (placeId: string, filters: Record<string, string | undefined> = {}) =>
+      ["alerts", placeId, filters] as const,
+  },
   telemetry: {
     latest: (placeId: string, deviceId: string) =>
       ["telemetry", "latest", placeId, deviceId] as const,

--- a/src/shared/composables/useMqtt.ts
+++ b/src/shared/composables/useMqtt.ts
@@ -2,12 +2,13 @@ import { ref, onMounted, onUnmounted, type Ref } from "vue";
 import mqtt from "mqtt";
 import { api } from "@/shared/api/client";
 import type { MqttCredentials } from "@/shared/types";
+import type { Alert, AlertMqttPayload } from "@/entities/alert/model/types";
 
 export function useMqtt(placeId: Ref<string> | string) {
   const latestValues = ref<Map<string, Map<string, { value: number; timestamp: string }>>>(
     new Map(),
   );
-  const alerts = ref<Array<Record<string, unknown>>>([]);
+  const alerts = ref<Alert[]>([]);
   const connected = ref(false);
 
   let client: mqtt.MqttClient | null = null;
@@ -42,7 +43,21 @@ export function useMqtt(placeId: Ref<string> | string) {
           latestValues.value = new Map(latestValues.value);
         }
       } else if (topic.endsWith("/alerts")) {
-        alerts.value = [...alerts.value.slice(-99), data];
+        const payload = data as Partial<AlertMqttPayload>;
+        if (!payload || typeof payload.id !== "string") return;
+        const { event_type, ...rest } = payload as AlertMqttPayload;
+        const alert: Alert = {
+          ...(rest as Omit<Alert, "status">),
+          status: event_type === "resolved" ? "resolved" : "active",
+        };
+        const existingIdx = alerts.value.findIndex((a) => a.id === alert.id);
+        if (existingIdx !== -1) {
+          const next = [...alerts.value];
+          next[existingIdx] = alert;
+          alerts.value = next;
+        } else {
+          alerts.value = [alert, ...alerts.value].slice(0, 100);
+        }
       }
     } catch {
       // Ignore parse errors

--- a/src/shared/ui/UiBadge.vue
+++ b/src/shared/ui/UiBadge.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 interface Props {
-  variant?: "default" | "accent" | "success" | "danger";
+  variant?: "default" | "accent" | "success" | "warning" | "danger";
 }
 
 withDefaults(defineProps<Props>(), {
@@ -11,7 +11,8 @@ const variantClasses = {
   default: "bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]",
   accent: "bg-[var(--color-accent-light)] text-[var(--color-accent)]",
   success: "bg-[var(--color-status-online-bg)] text-[var(--color-status-online-text)]",
-  danger: "bg-[var(--color-danger)]/10 text-[var(--color-danger)]",
+  warning: "bg-[var(--color-warning-bg)] text-[var(--color-warning-text)]",
+  danger: "bg-[var(--color-danger-bg)] text-[var(--color-danger-text)]",
 };
 </script>
 

--- a/src/shared/ui/UiToastContainer.vue
+++ b/src/shared/ui/UiToastContainer.vue
@@ -9,7 +9,7 @@ const { isDesktop } = useBreakpoint();
 <template>
   <Teleport to="body">
     <div
-      :class="['fixed right-6 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-8' : 'bottom-20']"
+      :class="['fixed right-4 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-4' : 'bottom-20']"
       aria-live="polite"
     >
       <TransitionGroup name="toast">

--- a/src/shared/ui/UiToastContainer.vue
+++ b/src/shared/ui/UiToastContainer.vue
@@ -9,7 +9,7 @@ const { isDesktop } = useBreakpoint();
 <template>
   <Teleport to="body">
     <div
-      :class="['fixed right-4 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-6' : 'bottom-20']"
+      :class="['fixed right-6 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-8' : 'bottom-20']"
       aria-live="polite"
     >
       <TransitionGroup name="toast">

--- a/src/shared/ui/UiToastContainer.vue
+++ b/src/shared/ui/UiToastContainer.vue
@@ -9,7 +9,7 @@ const { isDesktop } = useBreakpoint();
 <template>
   <Teleport to="body">
     <div
-      :class="['fixed right-4 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-4' : 'bottom-20']"
+      :class="['fixed right-4 z-[100] flex flex-col gap-2', isDesktop ? 'bottom-6' : 'bottom-20']"
       aria-live="polite"
     >
       <TransitionGroup name="toast">


### PR DESCRIPTION
## Summary
Replaces the per-place alerts stub with a real alerts feed. Historical data is loaded from `GET /api/places/{placeId}/alerts` and merged with the live MQTT stream (`placebrain/{placeId}/alerts`), with filters for severity, sensor, status, and time period. Owners/admins can resolve active alerts inline via `POST /api/places/{placeId}/alerts/{alertId}/resolve`.

## Changes
- `entities/alert/model/types.ts`: `Alert`, `AlertMqttPayload`, filter/options constants, `timeRangeToIso` helper.
- `entities/alert/api/alert.api.ts`: `useAlerts(placeId, filters)` query and `useResolveAlert(placeId)` mutation.
- `shared/composables/useMqtt.ts`: typed `alerts` ref; dispatches on `event_type` — `created` prepends, `resolved` updates the row by id (cap 100).
- `pages/place-detail/context.ts` + `PlaceDetailPage.vue`: expose the live alerts ref to nested routes.
- `pages/place-alerts/PlaceAlertsPage.vue`: filter row (severity / sensor / status / period), merged list dedup'd by id, resolve button with toast feedback, empty state.
- `shared/api/query-keys.ts`: alerts key factory.

## Verification
- [x] `npx vue-tsc -b`, `npm run lint:fix`, `npm run format`, `npm run build` all clean.
- [x] `docker compose ps` from `infra/` — all services healthy while developing.
- [ ] Manual browser walkthrough of live alert arrival, filter toggling, and resolve action — not executed in this session; needs a click-through before merge.

Closes #3