### PR TITLE
feat(sidebar): alerts bell with unresolved count badge

### DIFF
--- a/src/entities/alert/api/alert.api.ts
+++ b/src/entities/alert/api/alert.api.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
 import { computed, type Ref } from "vue";
-import type { Alert, AlertListFilters } from "../model/types";
+import type { Alert, AlertListFilters, GlobalAlertCount } from "../model/types";
 import { api } from "@/shared/api/client";
 import { queryKeys } from "@/shared/api/query-keys";
 import type { PaginatedResponse } from "@/shared/api/types";
@@ -35,6 +35,18 @@ export function useAlerts(
   });
 }
 
+export function useGlobalAlertCount() {
+  return useQuery({
+    queryKey: queryKeys.alerts.globalCount(),
+    queryFn: async () => {
+      const { data } = await api.get<GlobalAlertCount>("/api/alerts/count");
+      return data;
+    },
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
 export function useResolveAlert(placeId: Ref<string> | string) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -46,6 +58,7 @@ export function useResolveAlert(placeId: Ref<string> | string) {
     onSuccess: () => {
       const pId = typeof placeId === "string" ? placeId : placeId.value;
       queryClient.invalidateQueries({ queryKey: ["alerts", pId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.globalCount() });
     },
   });
 }

--- a/src/entities/alert/model/types.ts
+++ b/src/entities/alert/model/types.ts
@@ -23,6 +23,11 @@ export interface AlertMqttPayload extends Omit<Alert, "status"> {
   event_type: AlertEventType;
 }
 
+export interface GlobalAlertCount {
+  total_unresolved: number;
+  by_place: Record<string, number>;
+}
+
 export interface AlertListFilters {
   severity?: AlertSeverity;
   sensor_id?: string;

--- a/src/shared/api/query-keys.ts
+++ b/src/shared/api/query-keys.ts
@@ -26,6 +26,7 @@ export const queryKeys = {
   alerts: {
     list: (placeId: string, filters: Record<string, string | undefined> = {}) =>
       ["alerts", placeId, filters] as const,
+    globalCount: () => ["alerts", "count", "global"] as const,
   },
   telemetry: {
     latest: (placeId: string, deviceId: string) =>

--- a/src/shared/composables/useMqtt.ts
+++ b/src/shared/composables/useMqtt.ts
@@ -1,6 +1,8 @@
 import { ref, onMounted, onUnmounted, type Ref } from "vue";
+import { useQueryClient } from "@tanstack/vue-query";
 import mqtt from "mqtt";
 import { api } from "@/shared/api/client";
+import { queryKeys } from "@/shared/api/query-keys";
 import type { MqttCredentials } from "@/shared/types";
 import type { Alert, AlertMqttPayload } from "@/entities/alert/model/types";
 
@@ -10,6 +12,7 @@ export function useMqtt(placeId: Ref<string> | string) {
   );
   const alerts = ref<Alert[]>([]);
   const connected = ref(false);
+  const queryClient = useQueryClient();
 
   let client: mqtt.MqttClient | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -58,6 +61,7 @@ export function useMqtt(placeId: Ref<string> | string) {
         } else {
           alerts.value = [alert, ...alerts.value].slice(0, 100);
         }
+        queryClient.invalidateQueries({ queryKey: queryKeys.alerts.globalCount() });
       }
     } catch {
       // Ignore parse errors

--- a/src/widgets/sidebar/ui/SidebarAlertsLink.vue
+++ b/src/widgets/sidebar/ui/SidebarAlertsLink.vue
@@ -3,11 +3,18 @@ import { computed } from "vue";
 import { useRoute } from "vue-router";
 import { Bell } from "lucide-vue-next";
 import { useUiStore } from "@/shared/stores/ui.store";
+import { useGlobalAlertCount } from "@/entities/alert/api/alert.api";
 
 const ui = useUiStore();
 const route = useRoute();
 const collapsed = computed(() => ui.sidebarCollapsed);
 const isActive = computed(() => route.name === "alerts");
+
+const { data: count } = useGlobalAlertCount();
+const unresolved = computed(() => count.value?.total_unresolved ?? 0);
+const hasAlerts = computed(() => unresolved.value > 0);
+const displayCount = computed(() => (unresolved.value > 99 ? "99+" : String(unresolved.value)));
+const badgeLabel = computed(() => `${unresolved.value} unresolved alerts`);
 </script>
 
 <template>
@@ -27,7 +34,15 @@ const isActive = computed(() => route.name === "alerts");
         v-if="isActive"
         class="absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-r-full bg-[var(--color-accent)]"
       />
-      <Bell class="h-6 w-6 shrink-0" />
+      <div class="relative shrink-0">
+        <Bell class="h-6 w-6" />
+        <span
+          v-if="hasAlerts && collapsed"
+          class="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-[var(--color-danger)] ring-2 ring-[var(--color-surface)]"
+          :aria-label="badgeLabel"
+          role="status"
+        />
+      </div>
       <span
         :class="[
           'text-sm font-medium whitespace-nowrap transition-opacity duration-200',
@@ -36,6 +51,14 @@ const isActive = computed(() => route.name === "alerts");
         :aria-hidden="collapsed"
         >Alerts</span
       >
+      <span
+        v-if="hasAlerts && !collapsed"
+        class="ml-auto inline-flex min-w-[1.25rem] h-5 items-center justify-center rounded-full bg-[var(--color-danger)] px-1.5 text-[11px] font-semibold text-white whitespace-nowrap transition-opacity duration-200"
+        :aria-label="badgeLabel"
+        role="status"
+      >
+        {{ displayCount }}
+      </span>
     </router-link>
   </div>
 </template>


### PR DESCRIPTION
## Summary
Показывает число нерешённых алертов по всем местам пользователя на пункте Alerts в сайдбаре — чтобы срочность была видна без перехода на страницу.

## Changes
- `useGlobalAlertCount()` дёргает `GET /api/alerts/count` (`total_unresolved` + `by_place`). Запрос стартует при маунте сайдбара и поллится каждые 30s.
- `useMqtt` инвалидирует `queryKeys.alerts.globalCount()` на каждом входящем алерте, так что для активного места обновление мгновенное.
- `useResolveAlert` также инвалидирует глобальный счётчик.
- `SidebarAlertsLink.vue` рендерит бэдж: число справа в раскрытом режиме, красная точка поверх иконки в свёрнутом. При нуле бэдж скрыт. `99+` при большом числе.
- Добавлен тип `GlobalAlertCount` и ключ `queryKeys.alerts.globalCount()`.

Follow-up #13 — заменить поллинг на глобальную MQTT-подписку.

## Verification
- [x] `npx vue-tsc -b` — чисто.
- [x] `npm run lint:fix`, `npm run format` — чисто.
- [x] Живой прогон в браузере сделан.

Closes #4